### PR TITLE
Feature: Support filetype related to frontend development

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The script comes with the following defaults:
             "*.tsx",
             "*.js",
             "*.jsx",
+            "*.html",
             "*.json",
             "*.go",
             "*.c",

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The script comes with the following defaults:
             "*.ts",
             "*.tsx",
             "*.js",
+            "*.jsx",
             "*.json",
             "*.go",
             "*.c",

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The script comes with the following defaults:
         enable = true,
         support_filetypes = {
             "*.ts",
+            "*.tsx",
             "*.js",
             "*.json",
             "*.go",

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -94,6 +94,7 @@ Plug "shellRaining/hlchunk.nvim"
             "*.ts",
             "*.tsx",
             "*.js",
+            "*.jsx",
             "*.json",
             "*.go",
             "*.c",

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -92,6 +92,7 @@ Plug "shellRaining/hlchunk.nvim"
         enable = true,
         support_filetypes = {
             "*.ts",
+            "*.tsx",
             "*.js",
             "*.json",
             "*.go",

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -95,6 +95,7 @@ Plug "shellRaining/hlchunk.nvim"
             "*.tsx",
             "*.js",
             "*.jsx",
+            "*.html",
             "*.json",
             "*.go",
             "*.c",

--- a/lua/hlchunk/options.lua
+++ b/lua/hlchunk/options.lua
@@ -19,6 +19,7 @@ local support_ft = {
     "*.ts",
     "*.tsx",
     "*.js",
+    "*.jsx",
     "*.json",
     "*.go",
     "*.c",

--- a/lua/hlchunk/options.lua
+++ b/lua/hlchunk/options.lua
@@ -17,6 +17,7 @@ local exclude_ft = {
 
 local support_ft = {
     "*.ts",
+    "*.tsx",
     "*.js",
     "*.json",
     "*.go",

--- a/lua/hlchunk/options.lua
+++ b/lua/hlchunk/options.lua
@@ -20,6 +20,7 @@ local support_ft = {
     "*.tsx",
     "*.js",
     "*.jsx",
+    "*.html",
     "*.json",
     "*.go",
     "*.c",


### PR DESCRIPTION
## Context

Some filetypes are not supported by `hlchunk.nvim`

## Screenshot

| filetype | before | after |
|--------|--------|------|
| `*.tsx` | <img width="945" alt="image" src="https://user-images.githubusercontent.com/16217316/229332741-4becdd40-4415-4608-9644-ec05c26088cb.png"> | <img width="945" alt="image" src="https://user-images.githubusercontent.com/16217316/229332601-e53c1486-edd2-42eb-b5ad-c1de363f50eb.png"> |
| `*.jsx` | <img width="945" alt="image" src="https://user-images.githubusercontent.com/16217316/229332725-8118abab-0404-4600-aac8-167e327f2c64.png"> | <img width="945" alt="image" src="https://user-images.githubusercontent.com/16217316/229332621-a21bec76-459d-48bb-883e-54d81273a2e0.png"> |
| `*.html` | <img width="945" alt="image" src="https://user-images.githubusercontent.com/16217316/229332717-ffa68b75-04ef-4801-8494-9d827e1f61f8.png"> | <img width="945" alt="image" src="https://user-images.githubusercontent.com/16217316/229332646-fced7eca-738f-42ff-9e8c-5ca5fc4345d4.png"> |
