### PR TITLE
Added optional (off by default) chunk treesitter support

### DIFF
--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -13,6 +13,8 @@ local support_ft = {
     "*.json",
     "*.go",
     "*.c",
+    "*.lua",
+    "*.py",
     "*.cpp",
     "*.rs",
     "*.h",
@@ -25,6 +27,7 @@ local chunk_mod = BaseMod:new({
     name = "chunk",
     options = {
         enable = true,
+        use_treesitter = false,
         support_filetypes = support_ft,
         chars = {
             horizontal_line = "─",
@@ -50,8 +53,10 @@ function chunk_mod:render()
 
     self:clear()
     ns_id = api.nvim_create_namespace("hlchunk")
-
-    local cur_chunk_range = utils.get_chunk_range()
+    
+    local cur_chunk_range =
+        self.options.use_treesitter and utils.get_chunk_range_ts()
+        or utils.get_chunk_range_ts()
     if cur_chunk_range and cur_chunk_range[1] < cur_chunk_range[2] then
         local beg_row, end_row = unpack(cur_chunk_range)
         local beg_blank_len = fn.indent(beg_row)

--- a/lua/hlchunk/mods/line_num.lua
+++ b/lua/hlchunk/mods/line_num.lua
@@ -11,6 +11,8 @@ local support_ft = {
     "*.json",
     "*.go",
     "*.c",
+    "*.lua",
+    "*.py",
     "*.cpp",
     "*.rs",
     "*.h",
@@ -22,6 +24,7 @@ local support_ft = {
 local line_num_mod = require("hlchunk.base_mod"):new({
     name = "line_num",
     options = {
+        use_treesitter = false,
         enable = true,
         style = "#806d9c",
         support_filetypes = support_ft,
@@ -35,7 +38,9 @@ function line_num_mod:render()
 
     self:clear()
 
-    local cur_chunk_range = utils.get_chunk_range()
+    local cur_chunk_range =
+        self.options.use_treesitter and utils.get_chunk_range_ts()
+        or utils.get_chunk_range()
     if cur_chunk_range and cur_chunk_range[1] < cur_chunk_range[2] then
         local beg_row, end_row = unpack(cur_chunk_range)
         for i = beg_row, end_row do

--- a/lua/hlchunk/utils/utils.lua
+++ b/lua/hlchunk/utils/utils.lua
@@ -3,6 +3,18 @@ local M = {}
 
 local fn = vim.fn
 
+function M.get_chunk_range_ts(line)
+    line = line or vim.api.nvim_get_current_line()
+    local beg_row, end_row
+    local node = require("nvim-treesitter.ts_utils").get_node_at_cursor()
+    if not node then return nil end
+    beg_row, _, end_row, _ = vim.treesitter.get_node_range(node)
+    if beg_row <= 0 or end_row <= 0 then
+        return nil
+    end
+    return {beg_row + 1, end_row + 1}
+end
+
 ---@param line? number the line number we want to get the chunk range
 ---@return table<number, number> | nil
 function M.get_chunk_range(line)


### PR DESCRIPTION
This adds treesitter support to anything that uses the `utils.get_chunk_range` function via a new function called `utils.get_chunk_range_ts`.

This is disabled by default, the mod will need to have `use_treesitter` enabled in order to use this.

This does however fix the issues mentioned with whitespace languages (such as lua and python) not having proper context highlighting

* Lua  
![image](https://user-images.githubusercontent.com/2640668/232360206-547b346a-34d0-4d02-a04f-34c3fb1d1e48.png)
![image](https://user-images.githubusercontent.com/2640668/232360237-671cdfcc-5582-4cf6-9a4e-66d2ece4b94b.png)

* Python  
![image](https://user-images.githubusercontent.com/2640668/232360406-4774d1ee-4421-48fb-946a-b003edfd03d6.png)
![image](https://user-images.githubusercontent.com/2640668/232360343-8c01a99c-17b0-449f-846b-9ca87f55cd58.png)
