### PR TITLE
Prevent error: index out of range (#23)

### DIFF
--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -109,7 +109,9 @@ function chunk_mod:render()
                 .. self.options.chars.right_arrow
 
             if not utils.col_in_screen(start_col) then
-                local utfBeg = vim.str_byteindex(end_virt_text, math.min(offset - start_col, virt_text_len))
+                local byte_idx = math.min(offset - start_col, virt_text_len)
+                if byte_idx >= fn.strwidth(end_virt_text) then byte_idx = fn.strwidth(end_virt_text) end
+                local utfBeg = vim.str_byteindex(end_virt_text, byte_idx)
                 end_virt_text = end_virt_text:sub(utfBeg + 1)
             end
             row_opts.virt_text = { { end_virt_text, "HLChunk1" } }

--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -91,6 +91,7 @@ function chunk_mod:render()
 
             if not utils.col_in_screen(start_col) then
                 local utfBeg = vim.str_byteindex(beg_virt_text, math.min(offset - start_col, virt_text_len))
+                print('debug utfBeg:', utfBeg)
                 beg_virt_text = beg_virt_text:sub(utfBeg + 1)
             end
 

--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -90,11 +90,9 @@ function chunk_mod:render()
                 .. self.options.chars.horizontal_line:rep(virt_text_len - 1)
 
             if not utils.col_in_screen(start_col) then
-                print('math.min:', math.min(offset - start_col, virt_text_len))
-                print('beg_virt_text:', beg_virt_text)
-                print('#beg_virt_text:', #beg_virt_text)
-                local utfBeg = vim.str_byteindex(beg_virt_text, math.max(math.min(offset - start_col, virt_text_len), 1) )
-                utfBeg = 1
+                local byte_idx = math.min(offset - start_col, virt_text_len)
+                if byte_idx >= fn.strwidth(beg_virt_text) then byte_idx = fn.strwidth(beg_virt_text) end
+                local utfBeg = vim.str_byteindex(beg_virt_text, byte_idx)
                 beg_virt_text = beg_virt_text:sub(utfBeg + 1)
             end
 

--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -90,8 +90,11 @@ function chunk_mod:render()
                 .. self.options.chars.horizontal_line:rep(virt_text_len - 1)
 
             if not utils.col_in_screen(start_col) then
-                local utfBeg = vim.str_byteindex(beg_virt_text, math.min(offset - start_col, virt_text_len))
-                print('debug utfBeg:', utfBeg)
+                print('math.min:', math.min(offset - start_col, virt_text_len))
+                print('beg_virt_text:', beg_virt_text)
+                print('#beg_virt_text:', #beg_virt_text)
+                local utfBeg = vim.str_byteindex(beg_virt_text, math.max(math.min(offset - start_col, virt_text_len), 1) )
+                utfBeg = 1
                 beg_virt_text = beg_virt_text:sub(utfBeg + 1)
             end
 

--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -91,7 +91,9 @@ function chunk_mod:render()
 
             if not utils.col_in_screen(start_col) then
                 local byte_idx = math.min(offset - start_col, virt_text_len)
-                if byte_idx > fn.strwidth(beg_virt_text) then byte_idx = fn.strwidth(beg_virt_text) end
+                if byte_idx > fn.strwidth(beg_virt_text) then
+                  byte_idx = fn.strwidth(beg_virt_text)
+                end
                 local utfBeg = vim.str_byteindex(beg_virt_text, byte_idx)
                 beg_virt_text = beg_virt_text:sub(utfBeg + 1)
             end
@@ -110,7 +112,9 @@ function chunk_mod:render()
 
             if not utils.col_in_screen(start_col) then
                 local byte_idx = math.min(offset - start_col, virt_text_len)
-                if byte_idx > fn.strwidth(end_virt_text) then byte_idx = fn.strwidth(end_virt_text) end
+                if byte_idx > fn.strwidth(end_virt_text) then
+                  byte_idx = fn.strwidth(end_virt_text)
+                end
                 local utfBeg = vim.str_byteindex(end_virt_text, byte_idx)
                 end_virt_text = end_virt_text:sub(utfBeg + 1)
             end

--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -91,7 +91,7 @@ function chunk_mod:render()
 
             if not utils.col_in_screen(start_col) then
                 local byte_idx = math.min(offset - start_col, virt_text_len)
-                if byte_idx >= fn.strwidth(beg_virt_text) then byte_idx = fn.strwidth(beg_virt_text) end
+                if byte_idx > fn.strwidth(beg_virt_text) then byte_idx = fn.strwidth(beg_virt_text) end
                 local utfBeg = vim.str_byteindex(beg_virt_text, byte_idx)
                 beg_virt_text = beg_virt_text:sub(utfBeg + 1)
             end
@@ -110,7 +110,7 @@ function chunk_mod:render()
 
             if not utils.col_in_screen(start_col) then
                 local byte_idx = math.min(offset - start_col, virt_text_len)
-                if byte_idx >= fn.strwidth(end_virt_text) then byte_idx = fn.strwidth(end_virt_text) end
+                if byte_idx > fn.strwidth(end_virt_text) then byte_idx = fn.strwidth(end_virt_text) end
                 local utfBeg = vim.str_byteindex(end_virt_text, byte_idx)
                 end_virt_text = end_virt_text:sub(utfBeg + 1)
             end


### PR DESCRIPTION
When getting the length of a nerd-font symbol by `#`, it returns `4`, but this is not correct in our case. Instead, we should use `fn.strwidth`, which will return `1`.