### PR TITLE
revisit: try detect `then`

### DIFF
--- a/lua/hlchunk/utils/filetype.lua
+++ b/lua/hlchunk/utils/filetype.lua
@@ -57,7 +57,6 @@ M.type_patterns = {
     "tuple",
     "do_block",
     "variable_declaration",
-    "block",
     "return",
 }
 


### PR DESCRIPTION
fix #18 again. caused by 5ae39ee

https://github.com/shellRaining/hlchunk.nvim/blob/df91a3a06563b11c715ca0a70df4119071a82da9/lua/hlchunk/utils/utils.lua#L74

To test it, try with/without this fix with the following Lua code: (observation: only happened to header `if A and B then`)

```lua
if vim.api.nvim_get_current_win() and vim.api.nvim_get_current_tabpage() then
  print('123') -- place the cursor here.
  print('123')
end
```

e.g.

<img src="https://github.com/shellRaining/hlchunk.nvim/assets/24765272/d06f4350-ec1a-4403-886d-ec8507c440d5" width="500">
<img src="https://github.com/shellRaining/hlchunk.nvim/assets/24765272/ce743b63-0198-4562-848e-197a56a21e00" width="500">

