### PR TITLE
feat: a simple implement for chunk textobject

### DIFF
--- a/lua/hlchunk/base_mod.lua
+++ b/lua/hlchunk/base_mod.lua
@@ -28,6 +28,9 @@ local BaseMod = {
 ---@field disable_mod_autocmd fun(self: BaseMod)
 ---@field create_mod_usercmd fun(self: BaseMod)
 ---@field set_options fun(self: BaseMod, options: table | nil)
+---@field extra fun(self:BaseMod)
+
+
 function BaseMod:new(o)
     o = o or {}
     o.augroup_name = o.augroup_name or ("hl_" .. o.name .. "_augroup")
@@ -44,6 +47,7 @@ function BaseMod:enable()
         self:render()
         self:enable_mod_autocmd()
         self:create_mod_usercmd()
+        self:extra()
     end)
     if not ok then
         vim.notify(tostring(info))
@@ -125,5 +129,10 @@ function BaseMod:set_options(options)
     end
     self.options = vim.tbl_deep_extend("force", self.options, options or {})
 end
+
+
+---This is a hook function, you can do some extra things when you enable mod
+---This is a empty implementation, you can override it
+function BaseMod:extra()end
 
 return BaseMod

--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -1,28 +1,29 @@
-local BaseMod = require("hlchunk.base_mod")
-local utils = require("hlchunk.utils.utils")
-local ft = require("hlchunk.utils.filetype")
+local BaseMod = require 'hlchunk.base_mod'
+local utils = require 'hlchunk.utils.utils'
+local ft = require 'hlchunk.utils.filetype'
 local api = vim.api
 local fn = vim.fn
 
-local chunk_mod = BaseMod:new({
-    name = "chunk",
+local chunk_mod = BaseMod:new {
+    name = 'chunk',
     options = {
         enable = true,
         use_treesitter = true,
         support_filetypes = ft.support_filetypes,
         exclude_filetypes = ft.exclude_filetypes,
         chars = {
-            horizontal_line = "─",
-            vertical_line = "│",
-            left_top = "╭",
-            left_bottom = "╰",
-            right_arrow = ">",
+            horizontal_line = '─',
+            vertical_line = '│',
+            left_top = '╭',
+            left_bottom = '╰',
+            right_arrow = '>',
         },
         style = {
-            { fg = "#806d9c" },
+            { fg = '#806d9c' },
         },
+        textobject = '',
     },
-})
+}
 
 -- set new virtual text to the right place
 function chunk_mod:render()
@@ -31,7 +32,7 @@ function chunk_mod:render()
     end
 
     self:clear()
-    self.ns_id = api.nvim_create_namespace("hlchunk")
+    self.ns_id = api.nvim_create_namespace 'hlchunk'
 
     local cur_chunk_range = utils.get_chunk_range(nil, { use_treesitter = self.options.use_treesitter })
     if cur_chunk_range and cur_chunk_range[1] < cur_chunk_range[2] then
@@ -42,8 +43,8 @@ function chunk_mod:render()
         local offset = fn.winsaveview().leftcol
 
         local row_opts = {
-            virt_text_pos = "overlay",
-            hl_mode = "combine",
+            virt_text_pos = 'overlay',
+            hl_mode = 'combine',
             priority = 100,
         }
 
@@ -62,7 +63,7 @@ function chunk_mod:render()
                 beg_virt_text = beg_virt_text:sub(utfBeg + 1)
             end
 
-            row_opts.virt_text = { { beg_virt_text, "HLChunk1" } }
+            row_opts.virt_text = { { beg_virt_text, 'HLChunk1' } }
             row_opts.virt_text_win_col = math.max(start_col - offset, 0)
             api.nvim_buf_set_extmark(0, self.ns_id, beg_row - 1, 0, row_opts)
         end
@@ -82,18 +83,18 @@ function chunk_mod:render()
                 local utfBeg = vim.str_byteindex(end_virt_text, byte_idx)
                 end_virt_text = end_virt_text:sub(utfBeg + 1)
             end
-            row_opts.virt_text = { { end_virt_text, "HLChunk1" } }
+            row_opts.virt_text = { { end_virt_text, 'HLChunk1' } }
             row_opts.virt_text_win_col = math.max(start_col - offset, 0)
             api.nvim_buf_set_extmark(0, self.ns_id, end_row - 1, 0, row_opts)
         end
 
         -- render middle section
         for i = beg_row + 1, end_row - 1 do
-            row_opts.virt_text = { { self.options.chars.vertical_line, "HLChunk1" } }
+            row_opts.virt_text = { { self.options.chars.vertical_line, 'HLChunk1' } }
             row_opts.virt_text_win_col = start_col - offset
-            local space_tab = (" "):rep(vim.o.shiftwidth)
-            local line_val = fn.getline(i):gsub("\t", space_tab)
-            if #fn.getline(i) <= start_col or line_val:sub(start_col + 1, start_col + 1):match("%s") then
+            local space_tab = (' '):rep(vim.o.shiftwidth)
+            local line_val = fn.getline(i):gsub('\t', space_tab)
+            if #fn.getline(i) <= start_col or line_val:sub(start_col + 1, start_col + 1):match '%s' then
                 if utils.col_in_screen(start_col) then
                     api.nvim_buf_set_extmark(0, self.ns_id, i - 1, 0, row_opts)
                 end
@@ -104,34 +105,52 @@ end
 
 function chunk_mod:enable_mod_autocmd()
     api.nvim_create_augroup(self.augroup_name, { clear = true })
-    api.nvim_create_autocmd({ "TextChanged" }, {
+    api.nvim_create_autocmd({ 'TextChanged' }, {
         group = self.augroup_name,
         pattern = self.options.support_filetypes,
         callback = function()
             chunk_mod:render()
         end,
     })
-    api.nvim_create_autocmd({ "TextChangedI", "CursorMovedI" }, {
+    api.nvim_create_autocmd({ 'TextChangedI', 'CursorMovedI' }, {
         group = self.augroup_name,
         pattern = self.options.support_filetypes,
         callback = function()
             chunk_mod:render()
         end,
     })
-    api.nvim_create_autocmd({ "CursorMoved" }, {
+    api.nvim_create_autocmd({ 'CursorMoved' }, {
         group = self.augroup_name,
         pattern = self.options.support_filetypes,
         callback = function()
             chunk_mod:render()
         end,
     })
-    api.nvim_create_autocmd({ "ColorScheme" }, {
+    api.nvim_create_autocmd({ 'ColorScheme' }, {
         group = self.augroup_name,
-        pattern = "*",
+        pattern = '*',
         callback = function()
             chunk_mod:enable()
         end,
     })
+end
+
+function chunk_mod:extra()
+    local textobject = self.options.textobject
+    if #textobject == 0 then return end
+    vim.keymap.set({ 'x', 'o' }, textobject, function()
+        local cur_chunk_range = utils.get_chunk_range(nil, { use_treesitter = self.options.use_treesitter })
+        if not cur_chunk_range then return end
+
+        local s_row, e_row = unpack(cur_chunk_range)
+        local ctrl_v = api.nvim_replace_termcodes('<C-v>', true, true, true)
+        local cur_mode = vim.fn.mode()
+        if cur_mode == 'v' or cur_mode == 'V' or cur_mode == ctrl_v then vim.cmd('normal! ' .. cur_mode) end
+
+        api.nvim_win_set_cursor(0, { s_row, 0 })
+        vim.cmd 'normal! V'
+        api.nvim_win_set_cursor(0, { e_row, 0 })
+    end)
 end
 
 return chunk_mod


### PR DESCRIPTION
更改:
1. 为base_mod添加了extra字段, 进行了空实现, 进行类派生添加额外命令的时候,可以使用extra字段
2. 为chunk的Option添加textobject字段
    - 类型: string
    - 默认值: ""
    - 行为说明: 长度为0时相当于disable[默认], 其余情况, 将该字段视为文本对象的键映射
    - 示例配置: "ai", 则可以使用dai, 删除chunk部分, vai, 选择chunk部分 ....  