### PR TITLE
fix: fix rendering issues that occur when 'shiftwidth' == 0

### DIFF
--- a/lua/hlchunk/mods/blank.lua
+++ b/lua/hlchunk/mods/blank.lua
@@ -33,11 +33,12 @@ function blank_mod:render_line(index, indent)
         hl_mode = "combine",
         priority = 1,
     }
-    local render_char_num = math.floor(indent / vim.o.shiftwidth)
+    local shiftwidth = fn.shiftwidth()
+    local render_char_num = math.floor(indent / shiftwidth)
     local win_info = fn.winsaveview()
     local text = ""
     for _ = 1, render_char_num do
-        text = text .. "." .. (" "):rep(vim.o.shiftwidth - 1)
+        text = text .. "." .. (" "):rep(shiftwidth - 1)
     end
     text = text:sub(win_info.leftcol + 1)
 
@@ -48,7 +49,7 @@ function blank_mod:render_line(index, indent)
             count = count + 1
             local Blank_chars_num = Array:from(self.options.chars):size()
             local Blank_style_num = Array:from(self.options.style):size()
-            local char = self.options.chars[(count - 1) % Blank_chars_num + 1]:rep(vim.o.shiftwidth)
+            local char = self.options.chars[(count - 1) % Blank_chars_num + 1]:rep(shiftwidth)
             local style = "HLBlank" .. tostring((count - 1) % Blank_style_num + 1)
             row_opts.virt_text = { { char, style } }
             row_opts.virt_text_win_col = i - 1
@@ -58,7 +59,7 @@ function blank_mod:render_line(index, indent)
 end
 
 function blank_mod:render()
-    if (not self.options.enable) or self.options.exclude_filetypes[vim.bo.filetype] or vim.o.shiftwidth == 0 then
+    if (not self.options.enable) or self.options.exclude_filetypes[vim.bo.filetype] or fn.shiftwidth() == 0 then
         return
     end
 

--- a/lua/hlchunk/mods/chunk.lua
+++ b/lua/hlchunk/mods/chunk.lua
@@ -75,7 +75,8 @@ function chunk_mod:render(opts)
         local beg_row, end_row = unpack(cur_chunk_range)
         local beg_blank_len = fn.indent(beg_row)
         local end_blank_len = fn.indent(end_row)
-        local start_col = math.max(math.min(beg_blank_len, end_blank_len) - vim.o.shiftwidth, 0)
+        local shiftwidth = fn.shiftwidth()
+        local start_col = math.max(math.min(beg_blank_len, end_blank_len) - shiftwidth, 0)
         local offset = fn.winsaveview().leftcol
 
         local get_width = api.nvim_strwidth
@@ -131,7 +132,7 @@ function chunk_mod:render(opts)
         for i = beg_row + 1, end_row - 1 do
             row_opts.virt_text = { { self.options.chars.vertical_line, "HLChunk1" } }
             row_opts.virt_text_win_col = start_col - offset
-            local space_tab = (" "):rep(vim.o.shiftwidth)
+            local space_tab = (" "):rep(shiftwidth)
             local line_val = fn.getline(i):gsub("\t", space_tab)
             if #line_val <= start_col or fn.indent(i) > start_col then
                 if utils.col_in_screen(start_col) then

--- a/lua/hlchunk/mods/context.lua
+++ b/lua/hlchunk/mods/context.lua
@@ -40,7 +40,8 @@ function context_mod:render()
     end
     local beg_row, end_row = unpack(indent_range)
 
-    local start_col = math.max(math.min(fn.indent(beg_row), fn.indent(end_row)) - vim.o.shiftwidth, 0)
+    local shiftwidth = fn.shiftwidth()
+    local start_col = math.max(math.min(fn.indent(beg_row), fn.indent(end_row)) - shiftwidth, 0)
     local row_opts = {
         virt_text_pos = "overlay",
         virt_text_win_col = start_col,
@@ -54,7 +55,7 @@ function context_mod:render()
         -- TODO: dont use HLContextStyle1, but use varible defined in base_mod
         row_opts.virt_text = { { self.options.chars[1], "HLContext1" } }
         row_opts.virt_text_win_col = start_col - offset
-        local space_tab = (" "):rep(vim.o.shiftwidth)
+        local space_tab = (" "):rep(shiftwidth)
         local line_val = fn.getline(i):gsub("\t", space_tab)
         if #fn.getline(i) <= start_col or line_val:sub(start_col + 1, start_col + 1):match("%s") then
             if utils.col_in_screen(start_col) then

--- a/lua/hlchunk/mods/indent.lua
+++ b/lua/hlchunk/mods/indent.lua
@@ -34,11 +34,12 @@ function indent_mod:render_line(index, indent)
         hl_mode = "combine",
         priority = 2,
     }
-    local render_char_num = math.floor(indent / vim.o.shiftwidth)
+    local shiftwidth = fn.shiftwidth()
+    local render_char_num = math.floor(indent / shiftwidth)
     local win_info = fn.winsaveview()
     local text = ""
     for _ = 1, render_char_num do
-        text = text .. "|" .. (" "):rep(vim.o.shiftwidth - 1)
+        text = text .. "|" .. (" "):rep(shiftwidth - 1)
     end
     text = text:sub(win_info.leftcol + 1)
 
@@ -59,7 +60,7 @@ function indent_mod:render_line(index, indent)
 end
 
 function indent_mod:render()
-    if (not self.options.enable) or self.options.exclude_filetypes[vim.bo.filetype] or vim.o.shiftwidth == 0 then
+    if (not self.options.enable) or self.options.exclude_filetypes[vim.bo.filetype] or fn.shiftwidth() == 0 then
         return
     end
 

--- a/lua/hlchunk/utils/utils.lua
+++ b/lua/hlchunk/utils/utils.lua
@@ -136,9 +136,10 @@ function M.get_indent_range(mod, line, opts)
         return nil
     end
 
-    if rows_indent_list[line + 1] and rows_indent_list[line + 1] == rows_indent_list[line] + vim.o.shiftwidth then
+    local shiftwidth = fn.shiftwidth()
+    if rows_indent_list[line + 1] and rows_indent_list[line + 1] == rows_indent_list[line] + shiftwidth then
         line = line + 1
-    elseif rows_indent_list[line - 1] and rows_indent_list[line - 1] == rows_indent_list[line] + vim.o.shiftwidth then
+    elseif rows_indent_list[line - 1] and rows_indent_list[line - 1] == rows_indent_list[line] + shiftwidth then
         line = line - 1
     end
 


### PR DESCRIPTION
Some users (or [plugins](https://github.com/tpope/vim-sleuth/commit/b6b4c3b237678f1214ea2eca0e3e50eaafb30e3a)) set 'shiftwidth' to 0 to make (n)vim fall back to 'tabstop'. Since this plugin currently doesn't read 'tabstop', a 'shiftwidth' value of 0 will cause wrong placement of extmarks.

This PR replaces `vim.o.shiftwidth` with [`vim.fn.shiftwidth()`](https://neovim.io/doc/user/builtin.html#shiftwidth()) to handle such cases.

---

This PR doesn't include fixes for rendering errors caused by ['vartabstop'](https://neovim.io/doc/user/options.html#'vartabstop') because virtually no one uses it. Even core plugins like nvim-treesitter don't care about it.