### PR TITLE
fix: #59

### DIFF
--- a/lua/hlchunk/utils/utils.lua
+++ b/lua/hlchunk/utils/utils.lua
@@ -145,7 +145,7 @@ function M.get_indent_range(mod, line, opts)
     line = line or fn.line(".")
     opts = opts or { use_treesitter = false }
 
-    local rows_indent_list = M.get_rows_indent(mod, nil, nil, {
+    local _, rows_indent_list = M.get_rows_indent(mod, nil, nil, {
         use_treesitter = opts.use_treesitter,
         virt_indent = true,
     })


### PR DESCRIPTION
I'm not really sure what the logic is behind what I fixed, but this likely never worked.

`utils.M.get_rows_indent` does _not_ return a list, it returns an unpacked list. This means that you need to capture **both** values being returned by the function. `rows_indent_list` was actually being assigned `utils.ROWS_INDENT_RETCODE.OK` instead of the indent list you are expecting.

So the fix here is (given how `rows_indent_list` is being used) is to capture the return code in a (currently) unused variable and then assign the returned list to `rows_indent_list`.

I would highly advise you review this fix as it does work but likely doesn't encompass what you were actually going for when you created `M.get_rows_indent`.
