### PR TITLE
Exclude `fugitiveblame` filetype

### DIFF
--- a/lua/hlchunk/utils/filetype.lua
+++ b/lua/hlchunk/utils/filetype.lua
@@ -42,6 +42,7 @@ M.exclude_filetypes = {
     sagafinder = true,
     sagaoutline = true,
     better_term = true,
+    fugitiveblame = true,
 }
 
 return M


### PR DESCRIPTION
When I open git blame view via fugitive, hlchunk.nvim notice: `no parse for fugitiveblame`.

<img width="775" alt="Snipaste_2023-08-20_15-33-21" src="https://github.com/shellRaining/hlchunk.nvim/assets/36906329/a91a6e6a-2f0f-406b-8d18-b174948d3950">

Indeed, the content of the `fugitiveblame` filetype is very simple and not indented, so excluding it can reduce interference to users.
