### PR TITLE
feat(chunk): add .left_arrow option

### DIFF
--- a/lua/hlchunk/mods/chunk/chunk_conf.lua
+++ b/lua/hlchunk/mods/chunk/chunk_conf.lua
@@ -24,6 +24,7 @@ local ChunkConf = class(BaseConf, function(self, conf)
         },
         use_treesitter = true,
         chars = {
+			left_arrow = "─",
             horizontal_line = "─",
             vertical_line = "│",
             left_top = "╭",

--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -61,7 +61,9 @@ function ChunkMod:render(range, opts)
     -- render beg_row
     if beg_blank_len > 0 then
         local virt_text_len = beg_blank_len - start_col
-        local beg_virt_text = self.conf.chars.left_top .. self.conf.chars.horizontal_line:rep(virt_text_len - 1)
+        local beg_virt_text = self.conf.chars.left_top
+			.. self.conf.chars.horizontal_line:rep(virt_text_len - 1)
+			.. self.conf.chars.left_arrow
         local virt_text, virt_text_win_col = chunkHelper.calc(beg_virt_text, start_col, leftcol)
         row_opts.virt_text = { { virt_text, text_hl } }
         row_opts.virt_text_win_col = virt_text_win_col


### PR DESCRIPTION
![image](https://github.com/shellRaining/hlchunk.nvim/assets/8136158/8a39b96e-17a9-443c-a78b-ad7fbd788507)

Allow configuring `left_arrow` for chunk.

Note: I can provide similiar PR to the `dev` branch.