### PR TITLE
add exclude_filetypes:oil

### DIFF
--- a/lua/hlchunk/utils/filetype.lua
+++ b/lua/hlchunk/utils/filetype.lua
@@ -65,6 +65,7 @@ M.exclude_filetypes = {
     sagarename = true,
     cmp_menu = true,
     ["null-ls-info"] = true,
+    oil = true,
 }
 
 return M


### PR DESCRIPTION
This ft is being used by [oil.nvim](https://github.com/stevearc/oil.nvim)