### PR TITLE
feat(treesitter): add preliminary support for zig

### DIFF
--- a/lua/hlchunk/utils/ts_node_type/init.lua
+++ b/lua/hlchunk/utils/ts_node_type/init.lua
@@ -3,6 +3,7 @@ local M = {}
 M.cpp = require("hlchunk.utils.ts_node_type.cpp")
 M.lua = require("hlchunk.utils.ts_node_type.lua")
 M.rust = require("hlchunk.utils.ts_node_type.rust")
+M.zig = require("hlchunk.utils.ts_node_type.zig")
 M.default = {
     "class",
     "^func",

--- a/lua/hlchunk/utils/ts_node_type/zig.lua
+++ b/lua/hlchunk/utils/ts_node_type/zig.lua
@@ -1,0 +1,13 @@
+return {
+    ["Block"] = true,
+    ["ContainerDecl"] = true,
+    ["FnCallArguments"] = true,
+    ["IfStatement"] = true,
+    ["IfExpr"] = true,
+    ["SwitchExpr"] = true,
+    ["LoopStatement"] = true,
+    ["FieldInit"] = true,
+    ["InitList"] = true,
+    ["SuffixExpr"] = true,
+    ["BinaryExpr"] = true,
+}


### PR DESCRIPTION
Introduce node types used in zig for treesitter based indenting.

These should cover most, if not all, basic as well as moderate statements; partially fixing #111