### PR TITLE
fix: excluded filetypes ignored on module enable

### DIFF
--- a/lua/hlchunk/mods/base_mod/init.lua
+++ b/lua/hlchunk/mods/base_mod/init.lua
@@ -43,7 +43,7 @@ function BaseMod:enable()
     local ok, info = pcall(function()
         self.conf.enable = true
         self:setHl()
-        self:render(Scope(0, fn.line("w0") - 1, fn.line("w$") - 1))
+        if self:shouldRender(0) then self:render(Scope(0, fn.line("w0") - 1, fn.line("w$") - 1)) end
         self:createAutocmd()
         self:createUsercmd()
     end)


### PR DESCRIPTION
This fixes an issue where excluded filetypes are ignored when a module is first enabled.