### PR TITLE
docs: make first heading look correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <p align='center'>
 <b>English</b> | <a href="./README.zh-CN.md">简体中文</a>
 </p>
+
 ## What can this plugin do
 
 Similar to [indent-blankline](https://github.com/lukas-reineke/indent-blankline.nvim), this plugin can highlight the indent line, and highlight the code chunk according to the current cursor position.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,6 +6,7 @@
 <p align='center'>
 <a href="./README.md">English</a> | <b>简体中文</b>
 </p>
+
 ## 这个插件可以做什么
 
 和 [indent-blankline.nvim](https://github.com/lukas-reineke/indent-blankline.nvim) 类似，这个插件可以用来高亮缩进线,并且还可以根据当前光标所处的位置，高亮所在代码块.


### PR DESCRIPTION
Markdown does not interpret hashes before a text to render it as a heading if the text is just below html code. I have added a line break in the English and Chinese version to render the header correctly.