### PR TITLE
fix: add fidget filetype to exclude_filetypes

### DIFF
--- a/lua/hlchunk/utils/filetype.lua
+++ b/lua/hlchunk/utils/filetype.lua
@@ -11,6 +11,7 @@ M.exclude_filetypes = {
     DiffviewFileHistory = true,
     DiffviewFiles = true,
     DressingInput = true,
+    fidget = true,
     fugitiveblame = true,
     glowpreview = true,
     help = true,


### PR DESCRIPTION
[fidget.nvim](https://github.com/j-hui/fidget.nvim) is a popular Neovim plugin that describes itself as an "Extensible UI for Neovim notifications and LSP progress messages". The indent guides in its UI appear to be rendering, as shown in this image:

![image](https://github.com/user-attachments/assets/3991399c-6c69-413d-8568-0ca2bfa4545a)

To address this, I added its filetype to the `exclude_filetype` table and enabled the exclusion by default, as this seems to be an error and could potentially harm performance.
