### PR TITLE
Add typings for `hlchunk.setup()`

### DIFF
--- a/lua/hlchunk/init.lua
+++ b/lua/hlchunk/init.lua
@@ -4,7 +4,7 @@ hlchunk.setup = function(userConf)
     for mod_name, mod_conf in pairs(userConf) do
         if mod_conf.enable then
             local mod_path = "hlchunk.mods." .. mod_name
-            local Mod = require(mod_path) --[[@as BaseMod]]
+            local Mod = require(mod_path) --[[@as HlChunk.BaseMod]]
             local mod = Mod(mod_conf)
             mod:enable()
         end

--- a/lua/hlchunk/init.lua
+++ b/lua/hlchunk/init.lua
@@ -1,5 +1,12 @@
 local hlchunk = {}
 
+---@class HlChunk.UserConf
+---@field blank? HlChunk.UserBlankConf
+---@field chunk? HlChunk.UserChunkConf
+---@field indent? HlChunk.UserIndentConf
+---@field line_num? HlChunk.UserLineNumConf
+
+---@param userConf HlChunk.UserConf
 hlchunk.setup = function(userConf)
     for mod_name, mod_conf in pairs(userConf) do
         if mod_conf.enable then

--- a/lua/hlchunk/mods/base_mod/base_conf.lua
+++ b/lua/hlchunk/mods/base_mod/base_conf.lua
@@ -1,24 +1,24 @@
 local class = require("hlchunk.utils.class")
 local ft = require("hlchunk.utils.filetype")
 
----@alias StyleType string | table<string, string> | table<string, table<string, string>>
+---@alias HlChunk.StyleType string | table<string, string> | table<string, table<string, string>>
 
----@class UserBaseConf
+---@class HlChunk.UserBaseConf
 ---@field enable? boolean
----@field style? StyleType
+---@field style? HlChunk.StyleType
 ---@field exclude_filetypes? table<string, boolean>
 ---@field notify? boolean
 ---@field priority? number
 
----@class BaseConf
+---@class HlChunk.BaseConf
 ---@field enable boolean
----@field style StyleType
+---@field style HlChunk.StyleType
 ---@field exclude_filetypes table<string, boolean>
 ---@field notify boolean
 ---@field priority number
----@field init fun(self: UserBaseConf, conf: table)
----@overload fun(conf?: UserBaseConf): BaseConf
----@overload fun(conf?: BaseConf): BaseConf
+---@field init fun(self: HlChunk.UserBaseConf, conf: table)
+---@overload fun(conf?: HlChunk.UserBaseConf): HlChunk.BaseConf
+---@overload fun(conf?: HlChunk.BaseConf): HlChunk.BaseConf
 local BaseConf = class(function(self, conf)
     local default_conf = {
         enable = false,
@@ -27,7 +27,7 @@ local BaseConf = class(function(self, conf)
         priority = 0,
         exclude_filetypes = ft.exclude_filetypes,
     }
-    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as BaseConf]]
+    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as HlChunk.BaseConf]]
     self.enable = conf.enable
     self.style = conf.style
     self.exclude_filetypes = conf.exclude_filetypes

--- a/lua/hlchunk/mods/base_mod/init.lua
+++ b/lua/hlchunk/mods/base_mod/init.lua
@@ -6,9 +6,9 @@ local cFunc = require("hlchunk.utils.cFunc")
 local api = vim.api
 local fn = vim.fn
 
----@param self BaseMod
----@param conf BaseConf
----@param meta MetaInfo
+---@param self HlChunk.BaseMod
+---@param conf HlChunk.BaseConf
+---@param meta HlChunk.MetaInfo
 local constrctor = function(self, conf, meta)
     local default_meta = {
         name = "",
@@ -21,22 +21,22 @@ local constrctor = function(self, conf, meta)
     self.conf = BaseConf(conf)
 end
 
----@class BaseMod
----@field meta MetaInfo include info just used in mod inside, user can't access it
----@field conf BaseConf user config
----@field init fun(self: BaseMod, conf: BaseConf, meta: MetaInfo) not used for init mod, but as super keyword when inherit
----@field enable fun(self: BaseMod) enable the mod, the main entry of the mod
----@field disable fun(self: BaseMod) disable the mod
----@field protected shouldRender fun(self: BaseMod, bufnr: number): boolean just a tool function
----@field protected render fun(self: BaseMod, range: Scope)
----@field protected clear fun(self: BaseMod, range: Scope)
----@field protected createUsercmd fun(self: BaseMod)
----@field protected createAutocmd fun(self: BaseMod)
----@field protected clearAutocmd fun(self: BaseMod)
----@field protected setHl fun(self: BaseMod)
----@field protected clearHl fun(self: BaseMod)
----@field protected notify fun(self: BaseMod, msg: string, level?: string, opts?: table)
----@overload fun(conf?: UserBaseConf, meta?: MetaInfo): BaseMod
+---@class HlChunk.BaseMod
+---@field meta HlChunk.MetaInfo include info just used in mod inside, user can't access it
+---@field conf HlChunk.BaseConf user config
+---@field init fun(self: HlChunk.BaseMod, conf: HlChunk.BaseConf, meta: HlChunk.MetaInfo) not used for init mod, but as super keyword when inherit
+---@field enable fun(self: HlChunk.BaseMod) enable the mod, the main entry of the mod
+---@field disable fun(self: HlChunk.BaseMod) disable the mod
+---@field protected shouldRender fun(self: HlChunk.BaseMod, bufnr: number): boolean just a tool function
+---@field protected render fun(self: HlChunk.BaseMod, range: HlChunk.Scope)
+---@field protected clear fun(self: HlChunk.BaseMod, range: HlChunk.Scope)
+---@field protected createUsercmd fun(self: HlChunk.BaseMod)
+---@field protected createAutocmd fun(self: HlChunk.BaseMod)
+---@field protected clearAutocmd fun(self: HlChunk.BaseMod)
+---@field protected setHl fun(self: HlChunk.BaseMod)
+---@field protected clearHl fun(self: HlChunk.BaseMod)
+---@field protected notify fun(self: HlChunk.BaseMod, msg: string, level?: string, opts?: table)
+---@overload fun(conf?: HlChunk.UserBaseConf, meta?: HlChunk.MetaInfo): HlChunk.BaseMod
 local BaseMod = class(constrctor)
 
 function BaseMod:enable()
@@ -84,7 +84,7 @@ function BaseMod:render(range)
 end
 
 -- TODO: API-indexing
----@param range Scope the range to clear, start line and end line all include, 0-index
+---@param range HlChunk.Scope the range to clear, start line and end line all include, 0-index
 function BaseMod:clear(range)
     local start = range.start
     local finish = range.finish + 1

--- a/lua/hlchunk/mods/base_mod/type.lua
+++ b/lua/hlchunk/mods/base_mod/type.lua
@@ -1,4 +1,4 @@
----@class MetaInfo
+---@class HlChunk.MetaInfo
 ---@field name string
 ---@field augroup_name string
 ---@field hl_base_name string

--- a/lua/hlchunk/mods/blank/blank_conf.lua
+++ b/lua/hlchunk/mods/blank/blank_conf.lua
@@ -1,16 +1,16 @@
 local class = require("hlchunk.utils.class")
 local IndentConf = require("hlchunk.mods.indent.indent_conf")
 
----@class UserBlankConf : UserIndentConf
+---@class HlChunk.UserBlankConf : HlChunk.UserIndentConf
 
----@class BlankConf : BaseConf
----@overload fun(conf?: UserIndentConf): IndentConf
+---@class HlChunk.BlankConf : HlChunk.BaseConf
+---@overload fun(conf?: HlChunk.UserIndentConf): HlChunk.IndentConf
 local BlankConf = class(IndentConf, function(self, conf)
     local default_conf = {
         priority = 9,
         chars = { "․" },
     }
-    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as IndentConf]]
+    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as HlChunk.IndentConf]]
     IndentConf.init(self, conf)
 
     self.priority = conf.priority

--- a/lua/hlchunk/mods/blank/init.lua
+++ b/lua/hlchunk/mods/blank/init.lua
@@ -19,8 +19,8 @@ local constuctor = function(self, conf, meta)
     self.conf = BlankConf(conf)
 end
 
----@class BlankMod: IndentMod
----@overload fun(conf?: UserIndentConf, meta?: MetaInfo): IndentMod
+---@class HlChunk.BlankMod: HlChunk.IndentMod
+---@overload fun(conf?: HlChunk.UserIndentConf, meta?: HlChunk.MetaInfo): HlChunk.IndentMod
 local BlankMod = class(IndentMod, constuctor)
 
 function BlankMod:renderLeader(bufnr, index, offset, shadow_char_num, row_opts)

--- a/lua/hlchunk/mods/chunk/chunk_conf.lua
+++ b/lua/hlchunk/mods/chunk/chunk_conf.lua
@@ -1,14 +1,14 @@
 local class = require("hlchunk.utils.class")
 local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 
----@class UserChunkConf : UserBaseConf
+---@class HlChunk.UserChunkConf : HlChunk.UserBaseConf
 ---@field use_treesitter? boolean
 ---@field chars? table<string, string>
 ---@field textobject? string
 ---@field max_file_size? number
 ---@field error_sign? boolean
 
----@class ChunkConf : BaseConf
+---@class HlChunk.ChunkConf : HlChunk.BaseConf
 ---@field use_treesitter boolean
 ---@field chars table<string, string>
 ---@field textobject string
@@ -16,7 +16,7 @@ local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 ---@field error_sign boolean
 ---@field duration number
 ---@field delay number
----@overload fun(conf?: table): ChunkConf
+---@overload fun(conf?: table): HlChunk.ChunkConf
 local ChunkConf = class(BaseConf, function(self, conf)
     local default_conf = {
         priority = 15,
@@ -39,7 +39,7 @@ local ChunkConf = class(BaseConf, function(self, conf)
         duration = 200,
         delay = 300,
     }
-    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as ChunkConf]]
+    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as HlChunk.ChunkConf]]
     BaseConf.init(self, conf)
 
     self.priority = conf.priority

--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -17,8 +17,8 @@ local rangeFromTo = chunkHelper.rangeFromTo
 local utf8Split = chunkHelper.utf8Split
 local shallowCmp = chunkHelper.shallowCmp
 
----@class ChunkMetaInfo : MetaInfo
----@field task LoopTask | nil
+---@class HlChunk.ChunkMetaInfo : HlChunk.MetaInfo
+---@field task HlChunk.LoopTask | nil
 ---@field pre_virt_text_list string[]
 ---@field pre_row_list number[]
 ---@field pre_virt_text_win_col_list number[]
@@ -44,11 +44,11 @@ local constructor = function(self, conf, meta)
     self.conf = ChunkConf(conf)
 end
 
----@class ChunkMod : BaseMod
----@field conf ChunkConf
----@field meta ChunkMetaInfo
----@field render fun(self: ChunkMod, range: Scope, opts?: {error: boolean, lazy: boolean})
----@overload fun(conf?: UserChunkConf, meta?: MetaInfo): ChunkMod
+---@class HlChunk.ChunkMod : HlChunk.BaseMod
+---@field conf HlChunk.ChunkConf
+---@field meta HlChunk.ChunkMetaInfo
+---@field render fun(self: HlChunk.ChunkMod, range: HlChunk.Scope, opts?: {error: boolean, lazy: boolean})
+---@overload fun(conf?: HlChunk.UserChunkConf, meta?: HlChunk.MetaInfo): HlChunk.ChunkMod
 local ChunkMod = class(BaseMod, constructor)
 
 -- chunk_mod can use text object, so add a new function extra to handle it

--- a/lua/hlchunk/mods/indent/indent_conf.lua
+++ b/lua/hlchunk/mods/indent/indent_conf.lua
@@ -1,19 +1,19 @@
 local class = require("hlchunk.utils.class")
 local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 
----@class UserIndentConf : UserBaseConf
+---@class HlChunk.UserIndentConf : HlChunk.UserBaseConf
 ---@field chars? string[]
 ---@field use_treesitter? boolean
 ---@field ahead_lines? number
 ---@field delay? number
 
----@class IndentConf : BaseConf
+---@class HlChunk.IndentConf : HlChunk.BaseConf
 ---@field use_treesitter boolean
 ---@field chars table<string, string>
 ---@field ahead_lines number
 ---@field delay number default 50ms
 ---@field filter_list table<number, function>
----@overload fun(conf?: UserIndentConf): IndentConf
+---@overload fun(conf?: HlChunk.UserIndentConf): HlChunk.IndentConf
 local IndentConf = class(BaseConf, function(self, conf)
     local default_conf = {
         style = { vim.api.nvim_get_hl(0, { name = "Whitespace" }) },
@@ -24,7 +24,7 @@ local IndentConf = class(BaseConf, function(self, conf)
         delay = 100,
         filter_list = {},
     }
-    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as IndentConf]]
+    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as HlChunk.IndentConf]]
     BaseConf.init(self, conf)
 
     self.style = conf.style

--- a/lua/hlchunk/mods/indent/init.lua
+++ b/lua/hlchunk/mods/indent/init.lua
@@ -11,7 +11,7 @@ local api = vim.api
 local fn = vim.fn
 local ROWS_INDENT_RETCODE = indentHelper.ROWS_INDENT_RETCODE
 
----@class IndentMetaInfo : MetaInfo
+---@class HlChunk.IndentMetaInfo : HlChunk.MetaInfo
 ---@field pre_leftcol number
 
 local constructor = function(self, conf, meta)
@@ -30,19 +30,19 @@ local constructor = function(self, conf, meta)
     self.conf = IndentConf(conf)
 end
 
----@class RenderInfo
+---@class HlChunk.RenderInfo
 ---@field lnum number
 ---@field virt_text_win_col number
 ---@field virt_text table
 ---@field level number
 
----@class IndentMod : BaseMod
----@field conf IndentConf
----@field meta IndentMetaInfo
----@field render fun(self: IndentMod, range: Scope, opts: {lazy: boolean})
----@field calcRenderInfo fun(self: IndentMod, range: Scope): RenderInfo
+---@class HlChunk.IndentMod : HlChunk.BaseMod
+---@field conf HlChunk.IndentConf
+---@field meta HlChunk.IndentMetaInfo
+---@field render fun(self: HlChunk.IndentMod, range: HlChunk.Scope, opts: {lazy: boolean})
+---@field calcRenderInfo fun(self: HlChunk.IndentMod, range: HlChunk.Scope): HlChunk.RenderInfo
 ---@field setmark function
----@overload fun(conf?: UserIndentConf, meta?: MetaInfo): IndentMod
+---@overload fun(conf?: HlChunk.UserIndentConf, meta?: HlChunk.MetaInfo): HlChunk.IndentMod
 local IndentMod = class(BaseMod, constructor)
 
 local indent_cache = Cache("bufnr", "line")

--- a/lua/hlchunk/mods/line_num/init.lua
+++ b/lua/hlchunk/mods/line_num/init.lua
@@ -6,7 +6,7 @@ local class = require("hlchunk.utils.class")
 local api = vim.api
 local CHUNK_RANGE_RET = chunkHelper.CHUNK_RANGE_RET
 
----@class LineNumMetaInfo : MetaInfo
+---@class HlChunk.LineNumMetaInfo : HlChunk.MetaInfo
 
 local constructor = function(self, conf, meta)
     local default_meta = {
@@ -21,11 +21,11 @@ local constructor = function(self, conf, meta)
     self.conf = LineNumConf(conf)
 end
 
----@class LineNumMod : BaseMod
----@field conf LineNumConf
----@field meta LineNumMetaInfo
----@field render fun(self: LineNumMod, range: Scope, opts?: {error: boolean})
----@overload fun(conf?: UserLineNumConf, meta?: MetaInfo): LineNumMod
+---@class HlChunk.LineNumMod : HlChunk.BaseMod
+---@field conf HlChunk.LineNumConf
+---@field meta HlChunk.LineNumMetaInfo
+---@field render fun(self: HlChunk.LineNumMod, range: HlChunk.Scope, opts?: {error: boolean})
+---@overload fun(conf?: HlChunk.UserLineNumConf, meta?: HlChunk.MetaInfo): HlChunk.LineNumMod
 local LineNumMod = class(BaseMod, constructor)
 
 function LineNumMod:render(range)

--- a/lua/hlchunk/mods/line_num/line_num_conf.lua
+++ b/lua/hlchunk/mods/line_num/line_num_conf.lua
@@ -1,19 +1,19 @@
 local class = require("hlchunk.utils.class")
 local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 
----@class UserLineNumConf : UserBaseConf
+---@class HlChunk.UserLineNumConf : HlChunk.UserBaseConf
 ---@field use_treesitter? boolean
 
----@class LineNumConf : BaseConf
+---@class HlChunk.LineNumConf : HlChunk.BaseConf
 ---@field use_treesitter boolean
----@overload fun(conf?: table): ChunkConf
+---@overload fun(conf?: table): HlChunk.ChunkConf
 local LineNumConf = class(BaseConf, function(self, conf)
     local default_conf = {
         style = "#806d9c",
         priority = 10,
         use_treesitter = false,
     }
-    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as LineNumConf]]
+    conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as HlChunk.LineNumConf]]
     BaseConf.init(self, conf)
 
     self.style = conf.style

--- a/lua/hlchunk/utils/cache.lua
+++ b/lua/hlchunk/utils/cache.lua
@@ -1,9 +1,9 @@
 local class = require("hlchunk.utils.class")
 
----@class Cache
+---@class HlChunk.Cache
 ---@field private cache table
 ---@field private keys table
----@overload fun(...):Cache
+---@overload fun(...):HlChunk.Cache
 local Cache = class(function(self, ...)
     self.keys = { ... } -- 在构造函数中保存键名
     self.cache = {}

--- a/lua/hlchunk/utils/chunkHelper.lua
+++ b/lua/hlchunk/utils/chunkHelper.lua
@@ -41,7 +41,7 @@ chunkHelper.CHUNK_RANGE_RET = {
     NO_TS = 3,
 }
 
----@param pos Pos 0-index (row, col)
+---@param pos HlChunk.Pos 0-index (row, col)
 local function get_chunk_range_by_context(pos)
     local base_flag = "nWz"
     local cur_row_val = vim.api.nvim_buf_get_lines(pos.bufnr, pos.row, pos.row + 1, false)[1]
@@ -57,7 +57,7 @@ local function get_chunk_range_by_context(pos)
     return chunkHelper.CHUNK_RANGE_RET.OK, Scope(pos.bufnr, beg_row - 1, end_row - 1)
 end
 
----@param pos Pos 0-index for row, 0-index for col, API-indexing
+---@param pos HlChunk.Pos 0-index for row, 0-index for col, API-indexing
 local function get_chunk_range_by_treesitter(pos)
     if not has_treesitter(pos.bufnr) then
         return chunkHelper.CHUNK_RANGE_RET.NO_TS, Scope(pos.bufnr, -1, -1)
@@ -87,9 +87,9 @@ local function get_chunk_range_by_treesitter(pos)
     return chunkHelper.CHUNK_RANGE_RET.NO_CHUNK, Scope(pos.bufnr, -1, -1)
 end
 
----@param opts? {pos: Pos, use_treesitter: boolean}
+---@param opts? {pos: HlChunk.Pos, use_treesitter: boolean}
 ---@return CHUNK_RANGE_RETCODE enum
----@return Scope
+---@return HlChunk.Scope
 function chunkHelper.get_chunk_range(opts)
     opts = opts or { use_treesitter = false }
 

--- a/lua/hlchunk/utils/indentHelper.lua
+++ b/lua/hlchunk/utils/indentHelper.lua
@@ -40,7 +40,7 @@ indentHelper.ROWS_INDENT_RETCODE = {
     NO_TS = 1,
 }
 
----@param range Scope
+---@param range HlChunk.Scope
 ---@return ROWS_INDENT_RETCODE
 ---@return table<number, number>
 local function get_rows_indent_by_context(range)
@@ -57,7 +57,7 @@ local function get_rows_indent_by_context(range)
     return indentHelper.ROWS_INDENT_RETCODE.OK, rows_indent
 end
 
----@param range Scope
+---@param range HlChunk.Scope
 ---@return ROWS_INDENT_RETCODE
 ---@return table<number, number>
 local function get_rows_indent_by_treesitter(range)
@@ -98,7 +98,7 @@ end
 -- 5.
 -- 6. this is shellRaining
 -- the virtual indent of line 3 is 4, and the virtual indent of line 5 is 0
----@param range Scope
+---@param range HlChunk.Scope
 ---@param opts? {use_treesitter: boolean, virt_indent: boolean}
 ---@return ROWS_INDENT_RETCODE enum
 ---@return table<number, number>

--- a/lua/hlchunk/utils/loopTask.lua
+++ b/lua/hlchunk/utils/loopTask.lua
@@ -35,16 +35,16 @@ local function createStrategy(name, total_time, step_num)
     end
 end
 
----@class LoopTask
+---@class HlChunk.LoopTask
 ---@field private timer uv_timer_t | nil uv_timer_t object from the LuaJIT runtime
 ---@field private fn function function that will be executed when the timer fires
 ---@field private data table table that contains any data that needs to be passed to the function
 ---@field private strategy string string that determines how the function is executed when the timer fires
 ---@field private time_intervals table<number> table of numbers that represent the time intervals
 ---@field progress number number that represents the current progress of the timer
----@field public start fun(self: LoopTask):nil function that starts the timer
----@field public stop fun(self: LoopTask):nil function that stops the timer
----@overload fun(fn: function, strategy: string, duration: number, ...: any):LoopTask
+---@field public start fun(self: HlChunk.LoopTask):nil function that starts the timer
+---@field public stop fun(self: HlChunk.LoopTask):nil function that stops the timer
+---@overload fun(fn: function, strategy: string, duration: number, ...: any):HlChunk.LoopTask
 local LoopTask = class(function(self, fn, strategy, duration, ...)
     self.data = transpose({ ... })
     self.timer = nil

--- a/lua/hlchunk/utils/position.lua
+++ b/lua/hlchunk/utils/position.lua
@@ -1,20 +1,20 @@
 local class = require("hlchunk.utils.class")
 local cFunc = require("hlchunk.utils.cFunc")
 
----@class Pos
+---@class HlChunk.Pos
 ---@field bufnr number
 ---@field row number 0-index API-indexing
 ---@field col number 0-index API-indexing
 ---0-indexing API-indexing, notice when use with nvim_win_get_cursor
 
----@overload fun(bufnr: number, row: number, col: number): Pos
+---@overload fun(bufnr: number, row: number, col: number): HlChunk.Pos
 local Pos = class(function(self, bufnr, row, col)
     self.bufnr = bufnr
     self.row = row
     self.col = col
 end)
 
----@param pos Pos
+---@param pos HlChunk.Pos
 ---@param expand_tab_width? number when the field is given, the tab will be expand to blank with the width, like "\t\t" -> "    " when the width is 2
 ---@return string
 function Pos.get_char_at_pos(pos, expand_tab_width)

--- a/lua/hlchunk/utils/scope.lua
+++ b/lua/hlchunk/utils/scope.lua
@@ -1,8 +1,8 @@
----@class Scope
+---@class HlChunk.Scope
 ---@field bufnr number
 ---@field start number
 ---@field finish number
----@overload fun(bufnr: number, start: number, finish: number): Scope
+---@overload fun(bufnr: number, start: number, finish: number): HlChunk.Scope
 ---0-indexing, include start and finish
 -- local Scope = class(constructor)
 local function Scope(bufnr, start, finish)


### PR DESCRIPTION
This PR contains two commits: one that adds a unique prefix to each workspace-local type name, as they may conflict with modules outside of this plugin, and one that allows users to get the proper typings by setting up the language server to do so.

Tested with [lazydev.nvim](https://github.com/folke/lazydev.nvim).

resolves #128 