### PR TITLE
fix: add `TelescopeResults` to excluded filetypes

### DIFF
--- a/lua/hlchunk/utils/filetype.lua
+++ b/lua/hlchunk/utils/filetype.lua
@@ -44,6 +44,7 @@ M.exclude_filetypes = {
     startuptime = true,
     starter = true,
     TelescopePrompt = true,
+    TelescopeResults = true,
     toggleterm = true,
     Trouble = true,
     trouble = true,


### PR DESCRIPTION
Fixes https://github.com/shellRaining/hlchunk.nvim/issues/137.