### PR TITLE
Add wide/multiple char string and nerd font support for chunk

### DIFF
--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -81,7 +81,7 @@ function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_
         local virt_text_len = beg_blank_len - start_col
         local beg_virt_text = self.conf.chars.left_top
             .. self.conf.chars.horizontal_line:rep(virt_text_len - 2)
-            .. self.conf.chars.left_arrow
+            .. (virt_text_len > 1 and self.conf.chars.left_arrow or "")
         local virt_text, virt_text_win_col = chunkHelper.calc(beg_virt_text, start_col, self.meta.leftcol)
         local char_list = fn.reverse(utf8Split(virt_text))
         vim.list_extend(virt_text_list, char_list)
@@ -112,12 +112,12 @@ function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_
         local virt_text_len = end_blank_len - start_col
         local end_virt_text = self.conf.chars.left_bottom
             .. self.conf.chars.horizontal_line:rep(virt_text_len - 2)
-            .. self.conf.chars.right_arrow
+            .. (virt_text_len > 1 and self.conf.chars.right_arrow or "")
         local virt_text, virt_text_win_col = chunkHelper.calc(end_virt_text, start_col, self.meta.leftcol)
         local char_list = utf8Split(virt_text)
         vim.list_extend(virt_text_list, char_list)
-        vim.list_extend(row_list, vim.fn["repeat"]({ range.finish }, virt_text_len))
-        vim.list_extend(virt_text_win_col_list, rangeFromTo(virt_text_win_col, virt_text_win_col + virt_text_len - 1))
+        vim.list_extend(row_list, vim.fn["repeat"]({ range.finish }, #char_list))
+        vim.list_extend(virt_text_win_col_list, rangeFromTo(virt_text_win_col, virt_text_win_col + #char_list - 1))
     end
 end
 

--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -114,23 +114,23 @@ function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_
         local virt_text, virt_text_win_col =
             chunkHelper.calc(beg_virt_text, start_col, self.meta.leftcol, self.meta.shiftwidth)
         local char_list = utf8Split(virt_text)
-        vim.list_extend(virt_text_list, vim.fn.reverse(char_list))
-        vim.list_extend(row_list, vim.fn["repeat"]({ range.start }, #char_list))
-        vim.list_extend(
+        chunkHelper.list_extend(virt_text_list, chunkHelper.listReverse(char_list))
+        chunkHelper.list_extend(row_list, chunkHelper.repeated(range.start, #char_list))
+        chunkHelper.list_extend(
             virt_text_win_col_list,
-            vim.fn.reverse(chunkHelper.getColList(char_list, virt_text_win_col, self.meta.shiftwidth))
+            chunkHelper.listReverse(chunkHelper.getColList(char_list, virt_text_win_col, self.meta.shiftwidth))
         )
     end
 
     local mid_row_nums = range.finish - range.start - 1
-    vim.list_extend(row_list, rangeFromTo((range.start + 1), (range.finish - 1)))
-    vim.list_extend(virt_text_win_col_list, vim.fn["repeat"]({ start_col - self.meta.leftcol }, mid_row_nums))
+    chunkHelper.list_extend(row_list, rangeFromTo((range.start + 1), (range.finish - 1)))
+    chunkHelper.list_extend(virt_text_win_col_list, chunkHelper.repeated(start_col - self.meta.leftcol, mid_row_nums))
     ---@type string[]
     local chars
     if start_col - self.meta.leftcol < 0 then
-        chars = vim.fn["repeat"]({ "" }, mid_row_nums)
+        chars = chunkHelper.repeated("", mid_row_nums)
     else
-        chars = vim.fn["repeat"]({ self.conf.chars.vertical_line }, mid_row_nums)
+        chars = chunkHelper.repeated(self.conf.chars.vertical_line, mid_row_nums)
         -- when use click `<<` or `>>` to indent, we should make sure the line would not encounter the indent char
         for i = 1, mid_row_nums do
             local line = cFunc.get_line(range.bufnr, range.start + i)
@@ -144,7 +144,7 @@ function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_
             end
         end
     end
-    vim.list_extend(virt_text_list, chars)
+    chunkHelper.list_extend(virt_text_list, chars)
 
     if end_blank_len > 0 then
         local virt_text_width = end_blank_len - start_col
@@ -183,9 +183,9 @@ function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_
         local virt_text, virt_text_win_col =
             chunkHelper.calc(end_virt_text, start_col, self.meta.leftcol, self.meta.shiftwidth)
         local char_list = utf8Split(virt_text)
-        vim.list_extend(virt_text_list, char_list)
-        vim.list_extend(row_list, vim.fn["repeat"]({ range.finish }, #char_list))
-        vim.list_extend(
+        chunkHelper.list_extend(virt_text_list, char_list)
+        chunkHelper.list_extend(row_list, chunkHelper.repeated(range.finish, #char_list))
+        chunkHelper.list_extend(
             virt_text_win_col_list,
             chunkHelper.getColList(char_list, virt_text_win_col, self.meta.shiftwidth)
         )

--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -123,7 +123,7 @@ function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_
     end
 
     local mid_row_nums = range.finish - range.start - 1
-    chunkHelper.list_extend(row_list, rangeFromTo((range.start + 1), (range.finish - 1)))
+    chunkHelper.list_extend(row_list, rangeFromTo(range.start + 1, range.finish - 1))
     chunkHelper.list_extend(virt_text_win_col_list, chunkHelper.repeated(start_col - self.meta.leftcol, mid_row_nums))
     ---@type string[]
     local chars

--- a/test/features/chunkHelper_spec.lua
+++ b/test/features/chunkHelper_spec.lua
@@ -23,7 +23,7 @@ describe("indentHelper", function()
             expect_res = testCase.render_res
             expect_offset = testCase.offset
 
-            local render_res, render_offset = chunkHelper.calc(str, col, leftcol)
+            local render_res, render_offset = chunkHelper.calc(str, col, leftcol, 1)
             assert.equals(render_res, expect_res)
             assert.equals(render_offset, expect_offset)
         end
@@ -82,6 +82,140 @@ describe("indentHelper", function()
         for _, testCase in ipairs(inputList) do
             local res = chunkHelper.shallowCmp(testCase.t1, testCase.t2)
             assert.equals(res, testCase.res)
+        end
+    end)
+
+    it("getColList happy path", function()
+        local inputList = {
+            { char_list = { "a", "b", "c" }, text_width = 3, leftcol = 0, res = { 0, 1, 2 } },
+            { char_list = { "a", "b", "c" }, text_width = 3, leftcol = 2, res = { 2, 3, 4 } },
+            -- ascii gt
+            { char_list = { "╰", "─", "─", ">" }, text_width = 4, leftcol = 0, res = { 0, 1, 2, 3 } },
+            -- unicode box drawings light left
+            { char_list = { "╰", "─", "─", "╴" }, text_width = 4, leftcol = 2, res = { 2, 3, 4, 5 } },
+            -- nerdfont nf-fa-arrow_circle_right + whitespace
+            { char_list = { "╰", "─", "", " " }, text_width = 4, leftcol = 4, res = { 4, 5, 6, 7 } },
+            -- cjk
+            { char_list = { "你", "好" }, text_width = 4, leftcol = 0, res = { 0, 2 } },
+            -- emoji
+            { char_list = { ">", "⏩", ">" }, text_width = 4, leftcol = 2, res = { 2, 3, 5 } },
+            {
+                char_list = { "1", "⏫", "-", "2", "3" },
+                text_width = 5,
+                leftcol = 0,
+                res = { 0, 1, 3, 4, 5 },
+            },
+        }
+
+        for _, testCase in ipairs(inputList) do
+            local res = chunkHelper.getColList(testCase.char_list, testCase.leftcol, 1)
+            assert.same(res, testCase.res)
+        end
+    end)
+
+    it("repeatToWidth happy path", function()
+        local inputList = {
+            { str = "1", width = 4, res = "1111" },
+            { str = "12", width = 4, res = "1212" },
+            { str = "12", width = 9, res = "121212121" },
+            { str = "１", width = 1, res = " " },
+            { str = "１", width = 9, res = "１１１１ " },
+            { str = "１2", width = 9, res = "１2１2１2" },
+            { str = "1２", width = 9, res = "1２1２1２" },
+            { str = "１2", width = 10, res = "１2１2１2 " },
+            { str = "1２", width = 10, res = "1２1２1２1" },
+            { str = "⏻ ", width = 8, res = "⏻ ⏻ ⏻ ⏻ " },
+            { str = "⏻ ", width = 9, res = "⏻ ⏻ ⏻ ⏻  " },
+        }
+
+        for _, testCase in ipairs(inputList) do
+            local res = chunkHelper.repeatToWidth(testCase.str, testCase.width, 1)
+            assert.same(res, testCase.res)
+        end
+    end)
+
+    it("checkCellsBlank happy path", function()
+        -- bunch of edge cases
+        local inputList = {
+            { line = "", start_col = 1, end_col = 4, shiftwidth = 4, res = true },
+            { line = "", start_col = 3, end_col = 3, shiftwidth = 4, res = true },
+            { line = " ", start_col = 1, end_col = 4, shiftwidth = 4, res = true },
+            { line = " ", start_col = 3, end_col = 3, shiftwidth = 4, res = true },
+            { line = "    a", start_col = 1, end_col = 4, shiftwidth = 4, res = true },
+            { line = "    a", start_col = 3, end_col = 3, shiftwidth = 4, res = true },
+            { line = "a    ", start_col = 2, end_col = 5, shiftwidth = 4, res = true },
+            { line = "a    a", start_col = 2, end_col = 5, shiftwidth = 4, res = true },
+            { line = "　   a", start_col = 1, end_col = 5, shiftwidth = 4, res = true },
+            { line = "　   a", start_col = 1, end_col = 6, shiftwidth = 4, res = false },
+            { line = "a　  a", start_col = 2, end_col = 5, shiftwidth = 4, res = true },
+            { line = "a　  a", start_col = 2, end_col = 6, shiftwidth = 4, res = false },
+            { line = "     a", start_col = 1, end_col = 5, shiftwidth = 4, res = true },
+            { line = "     a", start_col = 1, end_col = 6, shiftwidth = 4, res = false },
+            { line = "a    a", start_col = 2, end_col = 5, shiftwidth = 4, res = true },
+            { line = "a    a", start_col = 2, end_col = 6, shiftwidth = 4, res = false },
+            { line = "aaaa a", start_col = 5, end_col = 5, shiftwidth = 4, res = true },
+            { line = "aaaa a", start_col = 5, end_col = 6, shiftwidth = 4, res = false },
+            { line = "a你a a", start_col = 5, end_col = 5, shiftwidth = 4, res = true },
+            { line = "a你a a", start_col = 5, end_col = 6, shiftwidth = 4, res = false },
+            { line = "aa　 a", start_col = 2, end_col = 5, shiftwidth = 4, res = false },
+            { line = "aa　 a", start_col = 3, end_col = 3, shiftwidth = 4, res = true },
+            { line = "aa　 a", start_col = 3, end_col = 5, shiftwidth = 4, res = true },
+            { line = "aa　 a", start_col = 3, end_col = 6, shiftwidth = 4, res = false },
+            { line = "aa　 a", start_col = 4, end_col = 4, shiftwidth = 4, res = true },
+            { line = "\ta ", start_col = 1, end_col = 4, shiftwidth = 4, res = true },
+            { line = "\ta ", start_col = 1, end_col = 4, shiftwidth = 3, res = false },
+            { line = " \ta", start_col = 1, end_col = 4, shiftwidth = 3, res = true },
+            { line = "\0   a", start_col = 1, end_col = 5, shiftwidth = 4, res = false },
+            { line = "\0   a", start_col = 2, end_col = 5, shiftwidth = 4, res = false },
+            { line = "\0   a", start_col = 3, end_col = 5, shiftwidth = 4, res = true },
+            { line = "你　 a", start_col = 1, end_col = 5, shiftwidth = 4, res = false },
+            { line = "你　 a", start_col = 2, end_col = 5, shiftwidth = 4, res = false },
+            { line = "你　 a", start_col = 3, end_col = 5, shiftwidth = 4, res = true },
+            { line = " 　 a", start_col = 1, end_col = 5, shiftwidth = 4, res = false },
+            { line = " 　 a", start_col = 2, end_col = 5, shiftwidth = 4, res = false },
+            { line = " 　 a", start_col = 3, end_col = 5, shiftwidth = 4, res = true },
+            { line = "你　 好", start_col = 3, end_col = 5, shiftwidth = 4, res = true },
+            { line = "你　 好", start_col = 2, end_col = 5, shiftwidth = 4, res = false },
+            { line = "你　 好", start_col = 3, end_col = 6, shiftwidth = 4, res = false },
+            { line = " 　  ", start_col = 3, end_col = 5, shiftwidth = 4, res = true },
+            { line = " 　  ", start_col = 2, end_col = 5, shiftwidth = 4, res = false },
+            { line = " 　  ", start_col = 3, end_col = 6, shiftwidth = 4, res = false },
+        }
+
+        for _, testCase in ipairs(inputList) do
+            local res =
+                chunkHelper.checkCellsBlank(testCase.line, testCase.start_col, testCase.end_col, testCase.shiftwidth)
+            assert.same(res, testCase.res)
+        end
+    end)
+
+    it("virtTextStrWidth happy path", function()
+        local inputList = {
+            { input = "\0", shiftwidth = 4, res = 0 },
+            { input = "\1", shiftwidth = 4, res = 2 },
+            { input = "\127", shiftwidth = 4, res = 2 },
+            { input = " ", shiftwidth = 4, res = 1 },
+            { input = "\t", shiftwidth = 4, res = 4 },
+            { input = "a", shiftwidth = 4, res = 1 },
+            { input = "A", shiftwidth = 4, res = 1 },
+            { input = "你", shiftwidth = 4, res = 2 },
+            { input = " ", shiftwidth = 4, res = 2 },
+            { input = "\0\0", shiftwidth = 4, res = 0 },
+            { input = "\1\1", shiftwidth = 4, res = 4 },
+            { input = "\127\127", shiftwidth = 4, res = 4 },
+            { input = "  ", shiftwidth = 4, res = 2 },
+            { input = "\t\t", shiftwidth = 4, res = 8 },
+            { input = "ab", shiftwidth = 4, res = 2 },
+            { input = "AB", shiftwidth = 4, res = 2 },
+            { input = "你好", shiftwidth = 4, res = 4 },
+            { input = "  ", shiftwidth = 4, res = 4 },
+            { input = "a\0b", shiftwidth = 4, stop_on_null = false, res = 2 },
+            { input = "a\0b", shiftwidth = 4, stop_on_null = true, res = 1 },
+        }
+
+        for _, testCase in ipairs(inputList) do
+            local res = chunkHelper.virtTextStrWidth(testCase.input, testCase.shiftwidth, testCase.stop_on_null)
+            assert.same(res, testCase.res)
         end
     end)
 end)

--- a/test/features/chunkHelper_spec.lua
+++ b/test/features/chunkHelper_spec.lua
@@ -134,6 +134,32 @@ describe("indentHelper", function()
         end
     end)
 
+    it("listReverse happy path", function()
+        local inputList = {
+            { t = {}, res = {} },
+            { t = { 1 }, res = { 1 } },
+            { t = { 1, 2, 3 }, res = { 3, 2, 1 } },
+            { t = { 1, 2, 3, 4 }, res = { 4, 3, 2, 1 } },
+        }
+
+        for _, testCase in ipairs(inputList) do
+            local res = chunkHelper.listReverse(testCase.t)
+            assert.same(res, testCase.res)
+        end
+    end)
+
+    it("repeated happy path", function()
+        local inputList = {
+            { input = 1, repeat_to = 1, res = { 1 } },
+            { input = 1, repeat_to = 3, res = { 1, 1, 1 } },
+        }
+
+        for _, testCase in ipairs(inputList) do
+            local res = chunkHelper.repeated(testCase.input, testCase.repeat_to)
+            assert.same(res, testCase.res)
+        end
+    end)
+
     it("checkCellsBlank happy path", function()
         -- bunch of edge cases
         local inputList = {
@@ -216,6 +242,19 @@ describe("indentHelper", function()
         for _, testCase in ipairs(inputList) do
             local res = chunkHelper.virtTextStrWidth(testCase.input, testCase.shiftwidth, testCase.stop_on_null)
             assert.same(res, testCase.res)
+        end
+    end)
+
+    it("list_extend happy path", function()
+        local inputList = {
+            { dst = { 1, 2, 3 }, src = {}, res = { 1, 2, 3 } },
+            { dst = {}, src = { 4, 5, 6 }, res = { 4, 5, 6 } },
+            { dst = { 1, 2, 3 }, src = { 4, 5, 6 }, res = { 1, 2, 3, 4, 5, 6 } },
+        }
+
+        for _, testCase in ipairs(inputList) do
+            chunkHelper.list_extend(testCase.dst, testCase.src)
+            assert.same(testCase.dst, testCase.res)
         end
     end)
 end)


### PR DESCRIPTION
This PR should fix

-   The rendering glitch that occurs when a non-single cell wide string is passed to the `chars` option.
-   The rendering glitch that occurs when the virtual text encounters a non-single cell wide character such as control characters, CJK characters, emoji, or nerd font icons.
-   The rendering glitch that occurs when the space is too small to draw both the line and the arrow of the chunk.
-   The rendering glitch caused by `"%s"` matching non-blank characters and not matching actually blank characters.
-   The rendering glitch caused by `vim.api.nvim_strwidth()` reporting incorrect string widths.

resolves #134

## Demo

### `main`

https://github.com/user-attachments/assets/a7700670-c74e-4650-b536-8c4d826a3b03

### This PR

https://github.com/user-attachments/assets/6c5d6314-5678-4339-9baa-aca7b4772120

## Real world performance

Performance is better for small to medium files thanks to reduced calls to slow APIs, but worse for large files due to strict checking.

### Performance on average

| filename                                         |     `main` |    this PR |
| :----------------------------------------------- | ---------: | ---------: |
| `lua/hlchunk/mods/base_mod/init.lua` (199 lines) | `0.620 ms` | `0.522 ms` |
| `src/nvim/buffer.c` (4254 lines)                 | `1.054 ms` | `1.265 ms` |
