### PR TITLE
feat(chunk): better textobject-keymap

### DIFF
--- a/docs/en/chunk.md
+++ b/docs/en/chunk.md
@@ -23,7 +23,7 @@ local default_conf = {
         left_bottom = "╰",
         right_arrow = ">",
     },
-    textobject = "",
+    textobject = {},
     max_file_size = 1024 * 1024,
     error_sign = true,
     -- animation related
@@ -45,7 +45,14 @@ The unique configuration options are `use_treesitter`, `chars`, `textobject`, `m
   - left_bottom
   - right_arrow
 
-- `textobject` is a string, which is empty by default. It is used to specify which string to use to represent the textobject. For example, I use `ic`, which stands for `inner chunk`, and you can modify it to other convenient characters.
+- `textobject` is a table, which is empty by default. This table contains two keys, `keymap` which triggers the textobject, and `desc` useful if you use a plugin like which-key, for instance this can be setup as follows:
+
+  ```lua
+  textobject = {
+      keymap = "ic",
+      desc = "inner chunk",
+  },
+  ```
 
 - `max_file_size` is a number, with a default of `1MB`. When the size of the opened file exceeds this value, the mod will be automatically turned off.
 

--- a/lua/hlchunk/mods/chunk/chunk_conf.lua
+++ b/lua/hlchunk/mods/chunk/chunk_conf.lua
@@ -4,14 +4,14 @@ local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 ---@class HlChunk.UserChunkConf : HlChunk.UserBaseConf
 ---@field use_treesitter? boolean
 ---@field chars? table<string, string>
----@field textobject? string
+---@field textobject? { keymap: string, desc: string }
 ---@field max_file_size? number
 ---@field error_sign? boolean
 
 ---@class HlChunk.ChunkConf : HlChunk.BaseConf
 ---@field use_treesitter boolean
 ---@field chars table<string, string>
----@field textobject string
+---@field textobject { keymap: string, desc: string }
 ---@field max_file_size number
 ---@field error_sign boolean
 ---@field duration number
@@ -33,7 +33,7 @@ local ChunkConf = class(BaseConf, function(self, conf)
             left_bottom = "╰",
             right_arrow = ">",
         },
-        textobject = "",
+        textobject = {},
         max_file_size = 1024 * 1024,
         error_sign = true,
         duration = 200,

--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -51,10 +51,8 @@ end
 ---@overload fun(conf?: HlChunk.UserChunkConf, meta?: HlChunk.MetaInfo): HlChunk.ChunkMod
 local ChunkMod = class(BaseMod, constructor)
 
--- chunk_mod can use text object, so add a new function extra to handle it
 function ChunkMod:enable()
     BaseMod.enable(self)
-    self:extra()
     self:render(Scope(0, 0, -1))
 end
 
@@ -239,14 +237,28 @@ function ChunkMod:createAutocmd()
             end
         end,
     })
+    api.nvim_create_autocmd("Filetype", {
+        group = self.meta.augroup_name,
+        callback = function()
+            -- chunk_mod can use text object, so add a new function extra to handle it
+            local ft = vim.bo[0].filetype
+            if not self.conf.exclude_filetypes[ft] then
+                self:extra()
+            end
+        end,
+    })
 end
 
 function ChunkMod:extra()
     local textobject = self.conf.textobject
-    if #textobject == 0 then
+    local keymap = textobject.keymap
+    local desc = textobject.desc
+
+    if not keymap or not desc then
         return
     end
-    vim.keymap.set({ "x", "o" }, textobject, function()
+
+    vim.keymap.set({ "x", "o" }, keymap, function()
         local pos = api.nvim_win_get_cursor(0)
         local retcode, cur_chunk_range = chunkHelper.get_chunk_range({
             pos = { bufnr = 0, row = pos[1] - 1, col = pos[2] },
@@ -266,7 +278,7 @@ function ChunkMod:extra()
         api.nvim_win_set_cursor(0, { s_row, 0 })
         vim.cmd("normal! V")
         api.nvim_win_set_cursor(0, { e_row, 0 })
-    end)
+    end, { desc = desc, buffer = true })
 end
 
 return ChunkMod

--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -254,7 +254,7 @@ function ChunkMod:extra()
     local keymap = textobject.keymap
     local desc = textobject.desc
 
-    if not keymap or not desc then
+    if not keymap then
         return
     end
 

--- a/test/features/class_spec.lua
+++ b/test/features/class_spec.lua
@@ -57,7 +57,7 @@ describe("ChunkConf class", function()
             left_bottom = "┗",
             right_arrow = "━",
         }
-        user_textobject = "ic"
+        user_textobject = { keymap = "ic", desc = "scope" }
         user_max_file_size = 10 * 1024 * 1024
         user_error_sign = true
         user_duration = 300


### PR DESCRIPTION
### What does this PR do ?

- Only set the **chunk-textobject-keymap** **Localy** to allowed-filetypes buffers so it doesn't conflict for instance with other keymaps in non-concerned/excluded buffers
- Add a keymap description to the textobject-keymap, useful for which-key users or other... so now you can set it up like this:

```lua
textobject = {
      keymap = "ic",
      desc = "inner chunk",
  },
```


### What's missing ?
Need someone to update the chinese docs :'/