### PR TITLE
fix(indent): use `WinScrolled` event to avoid interfering with folding

### DIFF
--- a/lua/hlchunk/mods/indent/init.lua
+++ b/lua/hlchunk/mods/indent/init.lua
@@ -191,8 +191,7 @@ function IndentMod:createAutocmd()
     end)
 
     local autocommands = {
-        { events = { "User" }, pattern = "WinScrolledX", opts = { lazy = false } },
-        { events = { "User" }, pattern = "WinScrolledY", opts = { lazy = true } },
+        { events = { "WinScrolled" }, opts = { lazy = true } },
         { events = { "TextChanged", "TextChangedI", "BufWinEnter" }, opts = { lazy = false } },
         { events = { "OptionSet" }, pattern = "list,shiftwidth,tabstop,expandtab", opts = { lazy = false } },
     }


### PR DESCRIPTION
### Description

Original issue: https://github.com/shellRaining/hlchunk.nvim/issues/143

When using the `WinScrolledX/Y` user events, navigating through folds can trigger the autocommands and cause the folds to be closed.

Using the native `WinScrolled` event instead seems to avoid the issue.

Disclaimer: I'm not sure why exactly this works :) I just saw that `mini.indentscope` uses the `WinScrolled` event and figured I'd give it a try. There seems to be something weird about the `WinScrolledX/Y` events anyway, because they're `User` events and I can't find any mention of them in the Neovim docs or source. The docs do mention though that `WinScrolled` is non-recursive, which could be relevant if the others aren't.

### Testing

- See reproduction steps in the original issue https://github.com/shellRaining/hlchunk.nvim/issues/143
- Or you can download my script where I ran into this issue, I can reproduce it there by toggling folds with `zR`/`zM` and navigating around: https://github.com/toupeira/dotfiles/blob/main/bin/dotfiles

I didn't notice any breakage, but I only discovered this plugin yesterday so I might be missing something :grinning: 

My config for the `indent` mod is very basic:

```lua
indent = {
  enable = true,
  style = '#222633',
},
```