### PR TITLE
fix: guard against invalid winid in WinScrolled callback

### DIFF
--- a/lua/hlchunk/mods/base_mod/init.lua
+++ b/lua/hlchunk/mods/base_mod/init.lua
@@ -156,6 +156,9 @@ function BaseMod:createAutocmd()
             for winid, changes in pairs(data) do
                 if winid ~= "all" then
                     winid = tonumber(winid) --[[@as number]]
+                    if not api.nvim_win_is_valid(winid) then
+                        return
+                    end
                     local bufnr = api.nvim_win_get_buf(winid)
                     if changes.topline ~= 0 then
                         api.nvim_exec_autocmds("User", {


### PR DESCRIPTION
This prevents runtime errors when transient windows like CopilotChat are closed. The `WinScrolled` autocommand was attempting to access a buffer from a window that no longer exists, triggering `nvim_win_get_buf` with an invalid window ID. This adds a guard using `nvim_win_is_valid(winid)` to ensure the callback only runs on valid windows.

Fixes noisy errors during rapid window closures and improves compatibility with plugins that use temporary floating windows.