### PR TITLE
fix(chunk): add virt_text_repeat_linebreak to fix holes on wrapped lines

### DIFF
--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -148,6 +148,7 @@ function ChunkMod:render(range, opts)
 
     local row_opts = {
         virt_text_pos = "overlay",
+        virt_text_repeat_linebreak = true,
         hl_mode = "combine",
         priority = 100,
     }


### PR DESCRIPTION
## Summary
Fixes chunk indicator gaps/holes when lines are soft-wrapped.

## Problem
When `wrap` is enabled, the vertical chunk indicator `│` shows gaps on wrapped line continuations:

![wrapped-line-holes](https://github.com/user-attachments/assets/65c7b31f-af44-465f-a824-6cf18b4a6f26)

This happens because the virtual text overlay doesn't repeat on soft line breaks by default.

## Solution
Add `virt_text_repeat_linebreak = true` to the extmark options in `row_opts`. This tells Neovim to repeat the virtual text on soft-wrapped line continuations.

See: https://neovim.io/doc/user/api.html#nvim_buf_set_extmark()
> virt_text_repeat_linebreak: if true, the virtual text will be repeated on wrapped lines

## Credits
- Thanks to @jas0xf for identifying the solution in #136
- Thanks to @knevan for reporting in #161

Fixes #136
Fixes #161