### PR TITLE
feat(nix): add Nix language support for nested scope detection

### DIFF
--- a/lua/hlchunk/mods/chunk/chunk_conf.lua
+++ b/lua/hlchunk/mods/chunk/chunk_conf.lua
@@ -7,6 +7,7 @@ local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 ---@field textobject? string
 ---@field max_file_size? number
 ---@field error_sign? boolean
+---@field node_type_styles? table<string, table> mapping of node type patterns to style
 
 ---@class HlChunk.ChunkConf : HlChunk.BaseConf
 ---@field use_treesitter boolean
@@ -16,6 +17,7 @@ local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 ---@field error_sign boolean
 ---@field duration number
 ---@field delay number
+---@field node_type_styles table<string, table> mapping of node type patterns to style
 ---@overload fun(conf?: table): HlChunk.ChunkConf
 local ChunkConf = class(BaseConf, function(self, conf)
     local default_conf = {
@@ -38,6 +40,21 @@ local ChunkConf = class(BaseConf, function(self, conf)
         error_sign = true,
         duration = 200,
         delay = 300,
+        -- Node type to style mapping (patterns matched against treesitter node type)
+        -- If a node type matches multiple patterns, first match wins
+        -- If no match, falls back to default style[1]
+        node_type_styles = {
+            -- Example config (users can override):
+            -- ["^func"] = { fg = "#99aee5" },      -- functions: blue
+            -- ["^if"] = { fg = "#c2a2e3" },        -- conditionals: purple
+            -- ["else"] = { fg = "#c2a2e3" },       -- else: purple
+            -- ["^for"] = { fg = "#fbdf90" },       -- for loops: yellow
+            -- ["^while"] = { fg = "#fbdf90" },     -- while loops: yellow
+            -- ["try"] = { fg = "#9fe8c3" },        -- try/catch: green
+            -- ["except"] = { fg = "#9fe8c3" },     -- except: green
+            -- ["catch"] = { fg = "#9fe8c3" },      -- catch: green
+            -- ["class"] = { fg = "#ef8891" },      -- classes: red
+        },
     }
     conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as HlChunk.ChunkConf]]
     BaseConf.init(self, conf)
@@ -50,6 +67,7 @@ local ChunkConf = class(BaseConf, function(self, conf)
     self.error_sign = conf.error_sign
     self.duration = conf.duration
     self.delay = conf.delay
+    self.node_type_styles = conf.node_type_styles
 end)
 
 return ChunkConf

--- a/lua/hlchunk/utils/chunkHelper.lua
+++ b/lua/hlchunk/utils/chunkHelper.lua
@@ -80,7 +80,7 @@ local function get_chunk_range_by_treesitter(pos)
         local node_start, _, node_end, _ = cursor_node:range()
         if node_start ~= node_end and is_suit_type(node_type) then
             return cursor_node:has_error() and chunkHelper.CHUNK_RANGE_RET.CHUNK_ERR or chunkHelper.CHUNK_RANGE_RET.OK,
-                Scope(pos.bufnr, node_start, node_end)
+                Scope(pos.bufnr, node_start, node_end, node_type)
         end
         local parent_node = cursor_node:parent()
         if parent_node == cursor_node then
@@ -88,7 +88,7 @@ local function get_chunk_range_by_treesitter(pos)
         end
         cursor_node = parent_node
     end
-    return chunkHelper.CHUNK_RANGE_RET.NO_CHUNK, Scope(pos.bufnr, -1, -1)
+    return chunkHelper.CHUNK_RANGE_RET.NO_CHUNK, Scope(pos.bufnr, -1, -1, nil)
 end
 
 ---@param opts? {pos: HlChunk.Pos, use_treesitter: boolean}

--- a/lua/hlchunk/utils/scope.lua
+++ b/lua/hlchunk/utils/scope.lua
@@ -2,14 +2,16 @@
 ---@field bufnr number
 ---@field start number
 ---@field finish number
----@overload fun(bufnr: number, start: number, finish: number): HlChunk.Scope
+---@field node_type? string treesitter node type (e.g., "function", "if_statement", "for_loop")
+---@overload fun(bufnr: number, start: number, finish: number, node_type?: string): HlChunk.Scope
 ---0-indexing, include start and finish
 -- local Scope = class(constructor)
-local function Scope(bufnr, start, finish)
+local function Scope(bufnr, start, finish, node_type)
     return {
         bufnr = bufnr,
         start = start,
         finish = finish,
+        node_type = node_type,
     }
 end
 

--- a/lua/hlchunk/utils/ts_node_type/init.lua
+++ b/lua/hlchunk/utils/ts_node_type/init.lua
@@ -3,6 +3,7 @@ local M = {}
 M.cpp = require("hlchunk.utils.ts_node_type.cpp")
 M.css = require("hlchunk.utils.ts_node_type.css")
 M.lua = require("hlchunk.utils.ts_node_type.lua")
+M.nix = require("hlchunk.utils.ts_node_type.nix")
 M.rust = require("hlchunk.utils.ts_node_type.rust")
 M.yaml = require("hlchunk.utils.ts_node_type.yaml")
 M.zig = require("hlchunk.utils.ts_node_type.zig")

--- a/lua/hlchunk/utils/ts_node_type/nix.lua
+++ b/lua/hlchunk/utils/ts_node_type/nix.lua
@@ -1,0 +1,17 @@
+-- Nix-specific treesitter node types for hlchunk
+-- Covers: let expressions, attribute sets, lambda functions, with expressions, etc.
+-- Format: node_type = true (table with keys, not array)
+return {
+    let_expression = true,          -- let ... in ...
+    attrset_expression = true,      -- { ... }
+    rec_attrset_expression = true,  -- rec { ... }
+    list_expression = true,         -- [ ... ]
+    lambda_expression = true,       -- arg: body
+    function_expression = true,     -- { args }: body  
+    with_expression = true,         -- with ...; ...
+    if_expression = true,           -- if ... then ... else ...
+    assert_expression = true,       -- assert ...; ...
+    binding = true,                 -- name = value;
+    inherit = true,                 -- inherit ...;
+    inherit_from = true,            -- inherit (...) ...;
+}


### PR DESCRIPTION
## Summary
Adds Nix-specific treesitter node types for better chunk indicator support in Nix files.

## Problem
Currently, hlchunk only shows chunk indicators for top-level scopes in Nix files. Nix has many nested scope types (let expressions, attribute sets, lambda functions, etc.) that weren't being detected.

## Solution
Add `nix.lua` with Nix-specific treesitter node types as a table (not array):
- `let_expression` - `let ... in ...` blocks
- `attrset_expression` - `{ ... }` attribute sets
- `rec_attrset_expression` - `rec { ... }` recursive sets
- `list_expression` - `[ ... ]` lists
- `lambda_expression` - `arg: body` functions
- `function_expression` - `{ args }: body` functions
- `with_expression` - `with ...; ...` expressions
- `if_expression` - conditionals
- `assert_expression` - assertions
- `binding` - `name = value;` bindings

## Benefits
Better visual feedback when editing Nix flakes and configurations. Users can now see chunk indicators for:
- Input/output blocks in flakes
- Each host configuration
- Let bindings and their scopes
- Nested attribute sets
- Function definitions

Especially useful for NixOS configurations and flake structures.

## Testing
Tested on NixOS with Nix flakes and configuration files. Chunk indicators now appear for all nested scopes.