### PR TITLE
feat(chunk): straight line option

### DIFF
--- a/lua/hlchunk/mods/chunk/chunk_conf.lua
+++ b/lua/hlchunk/mods/chunk/chunk_conf.lua
@@ -7,6 +7,7 @@ local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 ---@field textobject? string
 ---@field max_file_size? number
 ---@field error_sign? boolean
+---@field straight? boolean
 
 ---@class HlChunk.ChunkConf : HlChunk.BaseConf
 ---@field use_treesitter boolean
@@ -16,6 +17,7 @@ local BaseConf = require("hlchunk.mods.base_mod.base_conf")
 ---@field error_sign boolean
 ---@field duration number
 ---@field delay number
+---@field straight boolean
 ---@overload fun(conf?: table): HlChunk.ChunkConf
 local ChunkConf = class(BaseConf, function(self, conf)
     local default_conf = {
@@ -38,6 +40,7 @@ local ChunkConf = class(BaseConf, function(self, conf)
         error_sign = true,
         duration = 200,
         delay = 300,
+        straight = false,
     }
     conf = vim.tbl_deep_extend("force", default_conf, conf or {}) --[[@as HlChunk.ChunkConf]]
     BaseConf.init(self, conf)
@@ -50,6 +53,7 @@ local ChunkConf = class(BaseConf, function(self, conf)
     self.error_sign = conf.error_sign
     self.duration = conf.duration
     self.delay = conf.delay
+    self.straight = conf.straight
 end)
 
 return ChunkConf

--- a/lua/hlchunk/mods/chunk/init.lua
+++ b/lua/hlchunk/mods/chunk/init.lua
@@ -75,9 +75,14 @@ end
 function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_col_list)
     local beg_blank_len = cFunc.get_indent(range.bufnr, range.start)
     local end_blank_len = cFunc.get_indent(range.bufnr, range.finish)
-    local start_col = math.max(math.min(beg_blank_len, end_blank_len) - self.meta.shiftwidth, 0)
+    local start_col
+    if self.conf.straight then
+        start_col = math.max(math.min(beg_blank_len, end_blank_len), 0)
+    else
+        start_col = math.max(math.min(beg_blank_len, end_blank_len) - self.meta.shiftwidth, 0)
+    end
 
-    if beg_blank_len > 0 then
+    if not self.conf.straight and beg_blank_len > 0 then
         local virt_text_len = beg_blank_len - start_col
         local beg_virt_text = self.conf.chars.left_top
             .. self.conf.chars.horizontal_line:rep(virt_text_len - 2)
@@ -108,7 +113,7 @@ function ChunkMod:get_chunk_data(range, virt_text_list, row_list, virt_text_win_
     end
     vim.list_extend(virt_text_list, chars)
 
-    if end_blank_len > 0 then
+    if not self.conf.straight and end_blank_len > 0 then
         local virt_text_len = end_blank_len - start_col
         local end_virt_text = self.conf.chars.left_bottom
             .. self.conf.chars.horizontal_line:rep(virt_text_len - 2)


### PR DESCRIPTION
- Added an option to use a straight line for the current scope

<img width="381" height="131" alt="image" src="https://github.com/user-attachments/assets/165e9a33-295e-4bb2-8791-79d1cccda5ad" />